### PR TITLE
Supporting comment headers

### DIFF
--- a/dist/lib/converter/factories/comment.js
+++ b/dist/lib/converter/factories/comment.js
@@ -49,9 +49,6 @@ function getRawComment(node) {
     if (comments && comments.length) {
         var comment = void 0;
         if (node.kind === ts.SyntaxKind.SourceFile) {
-            if (comments.length === 1) {
-                return null;
-            }
             comment = comments[0];
         }
         else {

--- a/src/lib/converter/factories/comment.ts
+++ b/src/lib/converter/factories/comment.ts
@@ -103,9 +103,6 @@ export function getRawComment(node: ts.Node): string | undefined {
     if (comments.length) {
         let comment: ts.CommentRange;
         if (node.kind === ts.SyntaxKind.SourceFile) {
-            if (comments.length === 1) {
-                return;
-            }
             comment = comments[0];
         } else {
             comment = comments[comments.length - 1];


### PR DESCRIPTION
**Current Issue**
If we do something like this where there's import right after the `@module comment block`, this file will be treated as its own module and will ignore `@module Voice`.
```
/**
 * @module Voice
 */

import Test from './test';

/**
 * @external
 */
class Device {
  static get testProp(): string {
    return 'my test value';
  }
}

export default Device;
```

To fix the above issue without updating `typedoc` npm module, we would need to add dummy comment block before the import statement like below. The reason why this happens is because latest typescript only treats a comment block at the top of the file when there's no code below it. This is a known issue and discussed here https://github.com/TypeStrong/typedoc/issues/603
```
/**
 * @module Voice
 */

/**
 * Imports
 * Dummy comment block
 */
import Test from './test';

/**
 * @external
 */
class Device {
  static get testProp(): string {
    return 'my test value';
  }
}

export default Device;
```

**Fix typedoc module**
Ideally, this needs to be fixed in the typedoc npm module. There's a recommended fix mentioned in the github issue above (https://github.com/TypeStrong/typedoc/issues/603) but it requires removing a piece of code, and no-one knows why that code was there. This PR is applying that fix. I didn't see any issues after applying it and this fix will only exists in our fork.